### PR TITLE
docs: change the import line

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npx pod-install
 ## Usage
 
 ```js
-import NotificationBadge from 'react-native-notification-badge';
+import NotificationBadge from '@msml/react-native-notification-badge';
 ```
 
 ### Configure (android only)


### PR DESCRIPTION
The import line causes an error because of the missing import part `@msml/`, this PR fixes that